### PR TITLE
Fix Portctl deploys

### DIFF
--- a/lib/tasks/version.rake
+++ b/lib/tasks/version.rake
@@ -38,7 +38,7 @@ namespace :version do
 
     def update_version_and_push_changes(method_name)
       raise "\e[31mYou must be on the master branch to bump a version, switch to master branch and try again!\e[0m" unless get_branch == 'master'
-      puts "\e[92mEnter your version changes summary bellow:\e[0m"
+      puts "\e[92mEnter your version changes summary below:\e[0m"
       message = STDIN.gets.chomp
       raise ArgumentError, "Message can't be blank!" if message == nil || message == ''
 
@@ -112,7 +112,7 @@ namespace :version do
     end
 
     def deploy_app
-      system "portctl deploy #{port_control_name} production"
+      system "portctl deploy --application=#{port_control_name} --environment=production"
     end
 
     def get_branch


### PR DESCRIPTION
Correct spelling of bellow, and update the portctl deploy to correctly send params under their env var keys